### PR TITLE
[FIX] info book icon positioning - visualizer.tsx

### DIFF
--- a/packages/visualizer/src/visualizer.tsx
+++ b/packages/visualizer/src/visualizer.tsx
@@ -748,8 +748,8 @@ function ViewNode({ data }: NodeProps<ViewNodeDefinition>) {
 
 function Description({ description }: { description: string }) {
   return (
-    <div className="relative rounded-md border border-muted/80 px-2 py-0.5 text-foreground/60">
-      <span className="absolute -top-2 left-1 flex gap-1 bg-background px-1">
+    <div className="relative rounded-md border border-muted/80 px-2 py-0.5 text-foreground/60 flex">
+      <span className="-top-2 left-1 flex gap-1 bg-background pr-1">
         <Icon name="book-text" size="xs" />
       </span>
       <span


### PR DESCRIPTION
Current implementation puts the text and icon into different lines. Therefore it leads to immense table height changes when showing documentation in visualizer.

Fixes #

# Description

Please include a summary of the change and which issue is fixed, if any. Please also include relevant motivation and context.
List any dependencies that are required for this change.

CSS (Tailwind) changes

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
