### PR TITLE
Drizzle Run - Update sqlite and postgres starter-01 schema template

### DIFF
--- a/apps/drizzle-run/app/registry/dialects/postgresql/presets/starter-01/schema.ts
+++ b/apps/drizzle-run/app/registry/dialects/postgresql/presets/starter-01/schema.ts
@@ -8,8 +8,8 @@ import { relations } from "drizzle-orm";
 import { integer, text, pgTable, timestamp, AnyPgColumn } from "drizzle-orm/pg-core";
 
 export const users = pgTable("users", {
-  id: integer("id").primaryKey().generatedByDefaultAsIdentity(),
-  name: text("name").notNull(),
+  id: integer().primaryKey().generatedByDefaultAsIdentity(),
+  name: text().notNull(),
   createdAt: timestamp("created_at", { precision: 3 }).notNull().defaultNow(),
 });
 
@@ -18,8 +18,8 @@ export const usersRelations = relations(users, ({ many }) => ({
 }));
 
 export const posts = pgTable("posts", {
-  id: integer("id").primaryKey().generatedByDefaultAsIdentity(),
-  content: text("content").notNull(),
+  id: integer().primaryKey().generatedByDefaultAsIdentity(),
+  content: text().notNull(),
   authorId: integer("author_id")
     .notNull()
     .references((): AnyPgColumn => users.id),

--- a/apps/drizzle-run/app/registry/dialects/sqlite/presets/starter-01/schema.ts
+++ b/apps/drizzle-run/app/registry/dialects/sqlite/presets/starter-01/schema.ts
@@ -8,8 +8,8 @@ import { relations } from "drizzle-orm";
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 export const users = sqliteTable("users", {
-  id: integer("id", { mode: "number" }).primaryKey({ autoIncrement: true }),
-  name: text("name").notNull(),
+  id: integer({ mode: "number" }).primaryKey({ autoIncrement: true }),
+  name: text().notNull(),
   createdAt: integer("created_at", { mode: "timestamp" })
     .notNull()
     .$defaultFn(() => new Date()),
@@ -20,8 +20,8 @@ export const usersRelations = relations(users, ({ many }) => ({
 }));
 
 export const posts = sqliteTable("posts", {
-  id: integer("id", { mode: "number" }).primaryKey({ autoIncrement: true }),
-  content: text("content").notNull(),
+  id: integer({ mode: "number" }).primaryKey({ autoIncrement: true }),
+  content: text().notNull(),
   authorId: integer("author_id")
     .notNull()
     .references(() => users.id),


### PR DESCRIPTION
Fixes #

# Description

Since drizzle-orm@0.34.0 column names are optional and no longer required.

This update is a small enhancement. I maintained the snake_case naming convention throughout to align with the Drizzle ORM documentation and best practices.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)